### PR TITLE
fix: normalize middleware names

### DIFF
--- a/ingress/fixtures/input/ingress_with_middleware_name.yml
+++ b/ingress/fixtures/input/ingress_with_middleware_name.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: test
+  namespace: testing
+  annotations:
+    ingress.kubernetes.io/frontend-entry-points: "web"
+    ingress.kubernetes.io/rule-type: "PathPrefixStrip"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /bar
+        backend:
+          serviceName: service1
+          servicePort: 80

--- a/ingress/fixtures/output_convertFile/ingress_rewrite_target.yml
+++ b/ingress/fixtures/output_convertFile/ingress_rewrite_target.yml
@@ -9,7 +9,7 @@ spec:
   - kind: Rule
     match: Host(`rewrite`) && PathPrefix(`/api`)
     middlewares:
-    - name: replace-path-rewrite/api
+    - name: replace-path-rewrite-api
       namespace: testing
     priority: 0
     services:
@@ -22,7 +22,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   creationTimestamp: null
-  name: replace-path-rewrite/api
+  name: replace-path-rewrite-api
   namespace: testing
 spec:
   replacePathRegex:

--- a/ingress/fixtures/output_convertFile/ingress_with_matcher_modifier.yml
+++ b/ingress/fixtures/output_convertFile/ingress_with_matcher_modifier.yml
@@ -11,7 +11,7 @@ spec:
   - kind: Rule
     match: Host(`traefik.tchouk`) && PathPrefix(`/bar`)
     middlewares:
-    - name: traefik.tchouk/bar
+    - name: traefik.tchouk-bar
       namespace: testing
     priority: 0
     services:
@@ -22,7 +22,7 @@ spec:
   - kind: Rule
     match: Host(`traefik.tchouk`) && PathPrefix(`/foo`)
     middlewares:
-    - name: traefik.tchouk/foo
+    - name: traefik.tchouk-foo
       namespace: testing
     priority: 0
     services:
@@ -35,7 +35,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   creationTimestamp: null
-  name: traefik.tchouk/bar
+  name: traefik.tchouk-bar
   namespace: testing
 spec:
   stripPrefix:
@@ -46,7 +46,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   creationTimestamp: null
-  name: traefik.tchouk/foo
+  name: traefik.tchouk-foo
   namespace: testing
 spec:
   stripPrefix:

--- a/ingress/fixtures/output_convertFile/ingress_with_middleware_name.yml
+++ b/ingress/fixtures/output_convertFile/ingress_with_middleware_name.yml
@@ -1,0 +1,32 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  creationTimestamp: null
+  name: test
+  namespace: testing
+spec:
+  entryPoints:
+  - web
+  routes:
+  - kind: Rule
+    match: PathPrefix(`/bar`)
+    middlewares:
+    - name: bar
+      namespace: testing
+    priority: 0
+    services:
+    - kind: Service
+      name: service1
+      namespace: testing
+      port: 80
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  creationTimestamp: null
+  name: bar
+  namespace: testing
+spec:
+  stripPrefix:
+    prefixes:
+    - /bar

--- a/ingress/fixtures/output_convertIngress/ingress_rewrite_target_01.yml
+++ b/ingress/fixtures/output_convertIngress/ingress_rewrite_target_01.yml
@@ -9,7 +9,7 @@ spec:
   - kind: Rule
     match: Host(`rewrite`) && PathPrefix(`/api`)
     middlewares:
-    - name: replace-path-rewrite/api
+    - name: replace-path-rewrite-api
       namespace: testing
     priority: 0
     services:

--- a/ingress/fixtures/output_convertIngress/ingress_rewrite_target_02.yml
+++ b/ingress/fixtures/output_convertIngress/ingress_rewrite_target_02.yml
@@ -2,7 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   creationTimestamp: null
-  name: replace-path-rewrite/api
+  name: replace-path-rewrite-api
   namespace: testing
 spec:
   replacePathRegex:

--- a/ingress/fixtures/output_convertIngress/ingress_with_matcher_modifier_01.yml
+++ b/ingress/fixtures/output_convertIngress/ingress_with_matcher_modifier_01.yml
@@ -11,7 +11,7 @@ spec:
   - kind: Rule
     match: Host(`traefik.tchouk`) && PathPrefix(`/bar`)
     middlewares:
-    - name: traefik.tchouk/bar
+    - name: traefik.tchouk-bar
       namespace: testing
     priority: 0
     services:
@@ -22,7 +22,7 @@ spec:
   - kind: Rule
     match: Host(`traefik.tchouk`) && PathPrefix(`/foo`)
     middlewares:
-    - name: traefik.tchouk/foo
+    - name: traefik.tchouk-foo
       namespace: testing
     priority: 0
     services:

--- a/ingress/fixtures/output_convertIngress/ingress_with_matcher_modifier_02.yml
+++ b/ingress/fixtures/output_convertIngress/ingress_with_matcher_modifier_02.yml
@@ -2,7 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   creationTimestamp: null
-  name: traefik.tchouk/bar
+  name: traefik.tchouk-bar
   namespace: testing
 spec:
   stripPrefix:

--- a/ingress/fixtures/output_convertIngress/ingress_with_matcher_modifier_03.yml
+++ b/ingress/fixtures/output_convertIngress/ingress_with_matcher_modifier_03.yml
@@ -2,7 +2,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
   creationTimestamp: null
-  name: traefik.tchouk/foo
+  name: traefik.tchouk-foo
   namespace: testing
 spec:
   stripPrefix:

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -320,6 +320,7 @@ func createRoutes(namespace string, rules []networking.IngressRule, annotations 
 
 				if stripPrefix {
 					middlewareName := strings.TrimPrefix(rule.Host+path.Path, `/`)
+					middlewareName = strings.TrimSuffix(middlewareName, `/`)
 					middlewareName = strings.ReplaceAll(middlewareName, "/", "-")
 					mi := getStripPrefix(path, middlewareName, namespace)
 					mis = append(mis, mi)

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -319,8 +319,7 @@ func createRoutes(namespace string, rules []networking.IngressRule, annotations 
 				rules = append(rules, fmt.Sprintf("%s(`%s`)", ruleType, path.Path))
 
 				if stripPrefix {
-					middlewareName := strings.TrimPrefix(rule.Host+path.Path, `/`)
-					middlewareName = strings.TrimSuffix(middlewareName, `/`)
+					middlewareName := strings.Trim(rule.Host+path.Path, `/`)
 					middlewareName = strings.ReplaceAll(middlewareName, "/", "-")
 					mi := getStripPrefix(path, middlewareName, namespace)
 					mis = append(mis, mi)

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -319,7 +319,7 @@ func createRoutes(namespace string, rules []networking.IngressRule, annotations 
 				rules = append(rules, fmt.Sprintf("%s(`%s`)", ruleType, path.Path))
 
 				if stripPrefix {
-					mi := getStripPrefix(path, rule.Host+path.Path, namespace)
+					mi := getStripPrefix(path, strings.ReplaceAll(rule.Host+path.Path, "/", ""), namespace)
 					mis = append(mis, mi)
 					miRefs = append(miRefs, toRef(mi))
 				}

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -319,7 +319,9 @@ func createRoutes(namespace string, rules []networking.IngressRule, annotations 
 				rules = append(rules, fmt.Sprintf("%s(`%s`)", ruleType, path.Path))
 
 				if stripPrefix {
-					mi := getStripPrefix(path, strings.ReplaceAll(rule.Host+path.Path, "/", ""), namespace)
+					middlewareName := strings.TrimPrefix(rule.Host+path.Path, `/`)
+					middlewareName = strings.ReplaceAll(middlewareName, "/", "-")
+					mi := getStripPrefix(path, middlewareName, namespace)
 					mis = append(mis, mi)
 					miRefs = append(miRefs, toRef(mi))
 				}

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -200,6 +200,10 @@ func Test_convertFile(t *testing.T) {
 			ingressFile: "ingress_with_request_modifier.yml",
 			objectCount: 2,
 		},
+		{
+			ingressFile: "ingress_with_middleware_name.yml",
+			objectCount: 1,
+		},
 	}
 
 	fixturesDir := filepath.Join("fixtures", "output_convertFile")

--- a/ingress/middlewares.go
+++ b/ingress/middlewares.go
@@ -424,7 +424,7 @@ func getReplacePathRegex(rule networking.IngressRule, path networking.HTTPIngres
 	middlewareName := "replace-path-" + rule.Host + path.Path
 
 	return &v1alpha1.Middleware{
-		ObjectMeta: v1.ObjectMeta{Name: middlewareName, Namespace: namespace},
+		ObjectMeta: v1.ObjectMeta{Name: normalizeObjectName(middlewareName), Namespace: namespace},
 		Spec: v1alpha1.MiddlewareSpec{
 			ReplacePathRegex: &dynamic.ReplacePathRegex{
 				Regex:       fmt.Sprintf("^%s(.*)", path.Path),
@@ -436,7 +436,7 @@ func getReplacePathRegex(rule networking.IngressRule, path networking.HTTPIngres
 
 func getStripPrefix(path networking.HTTPIngressPath, middlewareName, namespace string) *v1alpha1.Middleware {
 	return &v1alpha1.Middleware{
-		ObjectMeta: v1.ObjectMeta{Name: middlewareName, Namespace: namespace},
+		ObjectMeta: v1.ObjectMeta{Name: normalizeObjectName(middlewareName), Namespace: namespace},
 		Spec: v1alpha1.MiddlewareSpec{
 			StripPrefix: &dynamic.StripPrefix{Prefixes: []string{path.Path}},
 		},


### PR DESCRIPTION
Fixing CRD names using [Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) to generate a resource with a valid name.

Fix #21