### PR TITLE
Fix: set workdir in docker example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ You can use pre-compiled binaries:
 You can use a Docker image:
 
 ```sh
-docker run --rm -v ${PWD}:/data traefik/traefik-migration-tool <options here>
+docker run --rm -w /data -v ${PWD}:/data traefik/traefik-migration-tool <options here>
 ```
 
 ## Limits


### PR DESCRIPTION
Uniformize examples to work with docker by setting a `workdir` in the command.